### PR TITLE
Add Multi Vector Retriever Pipeline

### DIFF
--- a/evaluate/evaluate.py
+++ b/evaluate/evaluate.py
@@ -10,9 +10,13 @@ from ragas.metrics import (
     context_recall,
     faithfulness,
 )
+from ragas.run_config import RunConfig
 from pandas import DataFrame
 
 from callback_handlers.log_callback_handler import LogCallbackHandler
+
+_DEFAULT_MAX_RAGAS_RETRIES = 20
+_DEFAULT_MAX_RAGAS_WAIT_TIME_SECS = 500
 
 
 def evaluate(
@@ -71,7 +75,11 @@ def evaluate(
             faithfulness,
             answer_relevancy,
         ],
-        callbacks=[LogCallbackHandler('evaluate')]
+        callbacks=[LogCallbackHandler('evaluate')],
+        # More generous RunConfig since we could be sending many requests.
+        run_config=RunConfig(timeout=None, max_retries=_DEFAULT_MAX_RAGAS_RETRIES,
+                             max_wait=_DEFAULT_MAX_RAGAS_WAIT_TIME_SECS),
+        raise_exceptions=False
     )
 
     df = result.to_pandas()

--- a/loaders/directory_loader/directory_loader.py
+++ b/loaders/directory_loader/directory_loader.py
@@ -24,7 +24,6 @@ DEFAULT_CHUNK_OVERLAP = 50
 class DirectoryLoader(BaseLoader):
     '''Loads various file types in a directory into document representation'''
 
-
     def __init__(self, paths: List[str]):
         self.paths = paths
         super().__init__()

--- a/loaders/directory_loader/directory_loader.py
+++ b/loaders/directory_loader/directory_loader.py
@@ -17,12 +17,13 @@ from langchain_openai.embeddings import OpenAIEmbeddings
 
 from loaders.directory_loader.csv_loader import CSVLoader
 
+DEFAULT_CHUNK_SIZE = 1000
+DEFAULT_CHUNK_OVERLAP = 50
+
 
 class DirectoryLoader(BaseLoader):
     '''Loads various file types in a directory into document representation'''
 
-    _DEFAULT_CHUNK_SIZE = 1000
-    _DEFAULT_CHUNK_OVERLAP = 50
 
     def __init__(self, paths: List[str]):
         self.paths = paths
@@ -61,15 +62,14 @@ class DirectoryLoader(BaseLoader):
                 ('h4', 'Header 4')])
         # Split by ["\n\n", "\n", " ", ""] in order.
         return RecursiveCharacterTextSplitter(
-            chunk_size=DirectoryLoader._DEFAULT_CHUNK_SIZE,
-            chunk_overlap=DirectoryLoader._DEFAULT_CHUNK_OVERLAP)
+            chunk_size=DEFAULT_CHUNK_SIZE,
+            chunk_overlap=DEFAULT_CHUNK_OVERLAP)
 
     def load_and_split(self, text_splitter: TextSplitter = None) -> List[Document]:
         if text_splitter is None:
             # Split by ["\n\n", "\n", " ", ""] in order.
             text_splitter = RecursiveCharacterTextSplitter(
-                chunk_size=DirectoryLoader._DEFAULT_CHUNK_SIZE,
-                chunk_overlap=DirectoryLoader._DEFAULT_CHUNK_OVERLAP)
+                chunk_size=DEFAULT_CHUNK_SIZE, chunk_overlap=DEFAULT_CHUNK_OVERLAP)
         all_documents = self.load()
         split_documents = []
         for doc in all_documents:

--- a/loaders/email_loader/email_loader.py
+++ b/loaders/email_loader/email_loader.py
@@ -21,7 +21,6 @@ DEFAULT_CHUNK_OVERLAP = 50
 class EmailLoader(BaseLoader):
     '''Loads emails into document representation'''
 
-
     def __init__(self, email_client: EmailClient, search_options: EmailSearchOptions):
         self.email_client = email_client
         self.search_options = search_options

--- a/loaders/email_loader/email_loader.py
+++ b/loaders/email_loader/email_loader.py
@@ -14,12 +14,13 @@ import pandas as pd
 from loaders.email_loader.email_client import EmailClient
 from loaders.email_loader.email_search_options import EmailSearchOptions
 
+DEFAULT_CHUNK_SIZE = 500
+DEFAULT_CHUNK_OVERLAP = 50
+
 
 class EmailLoader(BaseLoader):
     '''Loads emails into document representation'''
 
-    _DEFAULT_CHUNK_SIZE = 500
-    _DEFAULT_CHUNK_OVERLAP = 50
 
     def __init__(self, email_client: EmailClient, search_options: EmailSearchOptions):
         self.email_client = email_client
@@ -76,8 +77,7 @@ class EmailLoader(BaseLoader):
         # Split by ["\n\n", "\n", " ", ""] in order.
         if text_splitter is None:
             text_splitter = RecursiveCharacterTextSplitter(
-                chunk_size=EmailLoader._DEFAULT_CHUNK_SIZE,
-                chunk_overlap=EmailLoader._DEFAULT_CHUNK_OVERLAP)
+                chunk_size=DEFAULT_CHUNK_SIZE, chunk_overlap=DEFAULT_CHUNK_OVERLAP)
 
         all_documents = self.load()
         split_documents = []

--- a/retrievers/auto_retriever.py
+++ b/retrievers/auto_retriever.py
@@ -1,33 +1,25 @@
 from typing import List
+import json
 
+from langchain.docstore.document import Document
+from langchain.retrievers.self_query.base import SelfQueryRetriever
 from langchain_core.embeddings import Embeddings
 from langchain_core.language_models import BaseChatModel
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableSerializable
 from langchain_core.vectorstores import VectorStore
+import pandas as pd
 
-from langchain.sql_database import SQLDatabase
-
-from langchain.retrievers.self_query.base import SelfQueryRetriever
-from langchain.docstore.document import Document
-
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.runnables import RunnablePassthrough
-import re
-from langchain_core.runnables import RunnableLambda
-
+from retrievers.base import BaseRetriever
 from settings import (DEFAULT_LLM,
                       DEFAULT_EMBEDDINGS,
                       DEFAULT_AUTO_META_PROMPT_TEMPLATE,
-                      DEFAULT_SQL_RETRIEVAL_PROMPT_TEMPLATE,
                       DEFAULT_CARDINALITY_THRESHOLD,
                       DEFAUlT_VECTOR_STORE, DEFAULT_CONTENT_COLUMN_NAME
                       )
-from utils import documents_to_df
-import pandas as pd
-import json
+from utils import documents_to_df, vector_store_from_documents
 
 
-class AutoRetriever:
+class AutoRetriever(BaseRetriever):
     """
     AutoRetrieval is a class that uses langchain to extract metadata from a dataframe and query it using self retrievers.
 
@@ -127,8 +119,10 @@ class AutoRetriever:
         """
         docs = []
         for _, row in self.data.iterrows():
-            metadata_dict = row.drop(self.content_column_name).dropna().to_dict()
-            docs.append(Document(page_content=row[self.content_column_name], metadata=metadata_dict))
+            metadata_dict = row.drop(
+                self.content_column_name).dropna().to_dict()
+            docs.append(
+                Document(page_content=row[self.content_column_name], metadata=metadata_dict))
 
         return docs
 
@@ -137,10 +131,11 @@ class AutoRetriever:
         Given data either List[Documents] pd.Dataframe,  use it to create a vectorstore.
         :return:
         """
-        documents = self.df_to_documents() if isinstance(self.data, pd.DataFrame) else self.data
-        return self.vectorstore.from_documents(documents, self.embeddings_model)
+        documents = self.df_to_documents() if isinstance(
+            self.data, pd.DataFrame) else self.data
+        return vector_store_from_documents(self.vectorstore, documents, self.embeddings_model)
 
-    def as_retriever(self):
+    def as_runnable(self) -> RunnableSerializable:
         """
         return the self-query retriever
         :return:
@@ -161,74 +156,6 @@ class AutoRetriever:
         :param question: str
         :return: List[Document]
         """
-        retriever = self.as_retriever()
+        retriever_runnable = self.as_runnable()
 
-        return retriever.get_relevant_documents(question)
-
-
-class SQLRetriever:
-    """
-    a retriever used to connect to a postgres DB with pgvector extension
-    """
-
-    def __init__(self,
-                 connection_string: str,
-                 llm: BaseChatModel = DEFAULT_LLM,
-                 embeddings_model: Embeddings = DEFAULT_EMBEDDINGS,
-                 prompt_template: dict = DEFAULT_SQL_RETRIEVAL_PROMPT_TEMPLATE
-                 ):
-        self.prompt_template = prompt_template
-
-        self.db = SQLDatabase.from_uri(connection_string)
-        self.llm = llm
-        self.embeddings_model = embeddings_model
-
-    @staticmethod
-    def format_prompt(prompt_template: str):
-        """
-        format prompt template
-
-        :return:
-        """
-        return ChatPromptTemplate.from_messages(
-            [("system", prompt_template), ("human", "{question}")]
-        )
-
-    def get_schema(self, _):
-        """
-        Get DB schema
-        :return:
-        """
-        return self.db.get_table_info()
-
-    def replace_brackets(self, match):
-        words_inside_brackets = match.group(1).split(", ")
-        embedded_words = [
-            str(self.embeddings_model.embed_query(word)) for word in words_inside_brackets
-        ]
-        return "', '".join(embedded_words)
-
-    def get_query(self, query):
-        sql_query = re.sub(r"\[([\w\s,]+)\]", self.replace_brackets, query)
-        return sql_query
-
-    @property
-    def sql_query_chain(self):
-        return (
-                RunnablePassthrough.assign(schema=self.get_schema)
-                | self.format_prompt(self.prompt_template["sql_query"])
-                | self.llm.bind(stop=["\nSQLResult:"])
-                | StrOutputParser()
-        )
-
-    def as_retriever(self):
-        return (
-                RunnablePassthrough.assign(query=self.sql_query_chain)
-                | RunnablePassthrough.assign(
-            schema=self.get_schema,
-            response=RunnableLambda(lambda x: self.db.run(self.get_query(x["query"]))),
-        )
-                | self.format_prompt(self.prompt_template["sql_result"])
-                | self.llm
-                | StrOutputParser()
-        )
+        return retriever_runnable.get_relevant_documents(question)

--- a/retrievers/base.py
+++ b/retrievers/base.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+from langchain_core.runnables import RunnableSerializable
+
+
+class BaseRetriever(ABC):
+    """Represents a base retriever for a RAG pipeline"""
+    @abstractmethod
+    def as_runnable(self) -> RunnableSerializable:
+        pass

--- a/retrievers/multi_vector_retriever.py
+++ b/retrievers/multi_vector_retriever.py
@@ -1,0 +1,64 @@
+from typing import List
+import uuid
+
+from langchain.docstore.document import Document
+from langchain.retrievers.multi_vector import MultiVectorRetriever as LangChainMultiVectorRetriever
+from langchain.storage import InMemoryByteStore
+from langchain.text_splitter import TextSplitter
+from langchain_core.embeddings import Embeddings
+from langchain_core.runnables import RunnableSerializable
+from langchain_core.stores import BaseStore
+from langchain_core.vectorstores import VectorStore
+
+from retrievers.base import BaseRetriever
+from settings import DEFAULT_EMBEDDINGS, DEFAUlT_VECTOR_STORE
+from utils import vector_store_from_documents
+
+_DEFAULT_ID_KEY = "doc_id"
+
+
+class MultiVectorRetriever(BaseRetriever):
+
+    """
+    MultiVectorRetriever stores multiple vectors per document.
+    """
+
+    def __init__(
+            self,
+            documents: List[Document],
+            id_key: str = _DEFAULT_ID_KEY,
+            vectorstore: VectorStore = DEFAUlT_VECTOR_STORE,
+            parentstore: BaseStore = None,
+            text_splitter: TextSplitter = None,
+            embeddings_model: Embeddings = DEFAULT_EMBEDDINGS
+    ):
+        self.vectorstore = vectorstore
+        self.parentstore = parentstore
+        if self.parentstore is None:
+            self.parentstore = InMemoryByteStore()
+        self.id_key = id_key
+        self.documents = documents
+        self.text_splitter = text_splitter
+        self.embeddings_model = embeddings_model
+
+    def as_runnable(self) -> RunnableSerializable:
+        doc_ids = []
+        split_docs = []
+        for doc in self.documents:
+            doc_id = str(uuid.uuid4())
+            sub_docs = self.text_splitter.split_documents([doc])
+            for sub_doc in sub_docs:
+                sub_doc.metadata[self.id_key] = doc_id
+            doc_ids.append(doc_id)
+            split_docs.extend(sub_docs)
+
+        store = vector_store_from_documents(
+            self.vectorstore, split_docs, self.embeddings_model)
+        retriever = LangChainMultiVectorRetriever(
+            vectorstore=store,
+            byte_store=self.parentstore,
+            id_key=self.id_key
+        )
+        retriever.docstore.mset(list(zip(doc_ids, self.documents)))
+
+        return retriever

--- a/retrievers/sql_retriever.py
+++ b/retrievers/sql_retriever.py
@@ -1,4 +1,3 @@
-from typing import List
 import re
 
 from langchain.sql_database import SQLDatabase

--- a/retrievers/sql_retriever.py
+++ b/retrievers/sql_retriever.py
@@ -1,0 +1,84 @@
+from typing import List
+import re
+
+from langchain.sql_database import SQLDatabase
+from langchain_core.embeddings import Embeddings
+from langchain_core.language_models import BaseChatModel
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda, RunnablePassthrough, RunnableSerializable
+
+from retrievers.base import BaseRetriever
+from settings import (DEFAULT_LLM,
+                      DEFAULT_EMBEDDINGS,
+                      DEFAULT_SQL_RETRIEVAL_PROMPT_TEMPLATE
+                      )
+
+
+class SQLRetriever(BaseRetriever):
+    """
+    A retriever used to connect to a postgres DB with pgvector extension
+    """
+
+    def __init__(self,
+                 connection_string: str,
+                 llm: BaseChatModel = DEFAULT_LLM,
+                 embeddings_model: Embeddings = DEFAULT_EMBEDDINGS,
+                 prompt_template: dict = DEFAULT_SQL_RETRIEVAL_PROMPT_TEMPLATE
+                 ):
+        self.prompt_template = prompt_template
+
+        self.db = SQLDatabase.from_uri(connection_string)
+        self.llm = llm
+        self.embeddings_model = embeddings_model
+
+    @staticmethod
+    def format_prompt(prompt_template: str):
+        """
+        format prompt template
+
+        :return:
+        """
+        return ChatPromptTemplate.from_messages(
+            [("system", prompt_template), ("human", "{question}")]
+        )
+
+    def get_schema(self, _):
+        """
+        Get DB schema
+        :return:
+        """
+        return self.db.get_table_info()
+
+    def replace_brackets(self, match):
+        words_inside_brackets = match.group(1).split(", ")
+        embedded_words = [
+            str(self.embeddings_model.embed_query(word)) for word in words_inside_brackets
+        ]
+        return "', '".join(embedded_words)
+
+    def get_query(self, query):
+        sql_query = re.sub(r"\[([\w\s,]+)\]", self.replace_brackets, query)
+        return sql_query
+
+    @property
+    def sql_query_chain(self):
+        return (
+            RunnablePassthrough.assign(schema=self.get_schema)
+            | self.format_prompt(self.prompt_template["sql_query"])
+            | self.llm.bind(stop=["\nSQLResult:"])
+            | StrOutputParser()
+        )
+
+    def as_runnable(self) -> RunnableSerializable:
+        return (
+            RunnablePassthrough.assign(query=self.sql_query_chain)
+            | RunnablePassthrough.assign(
+                schema=self.get_schema,
+                response=RunnableLambda(
+                    lambda x: self.db.run(self.get_query(x["query"]))),
+            )
+            | self.format_prompt(self.prompt_template["sql_result"])
+            | self.llm
+            | StrOutputParser()
+        )

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,15 @@
+from datetime import timedelta
 from typing import List
+import time
 
 import pandas as pd
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
+from langchain_core.vectorstores import VectorStore
 
+# gpt-3.5-turbo
+_DEFAULT_TPM_LIMIT = 60000
+_DEFAULT_RATE_LIMIT_INTERVAL = timedelta(seconds=10)
 
 def documents_to_df(content_column_name: str,
                     documents: List[Document],
@@ -33,3 +39,31 @@ def documents_to_df(content_column_name: str,
         df["embeddings"] = embeddings_model.embed_documents(df[content_column_name].tolist())
 
     return df
+
+
+def vector_store_from_documents(
+        vector_store: VectorStore,
+        documents: List[Document],
+        embeddings_model: Embeddings,
+        tpm_limit: int = _DEFAULT_TPM_LIMIT,
+        rate_limit_interval: timedelta = _DEFAULT_RATE_LIMIT_INTERVAL) -> VectorStore:
+    first_document = documents[0]
+    # Underlying rate limit mechanism behind this isn't sufficient for a bulk call.
+    # We can easily go above our tokens per minute quota (60 000 for gpt-3.5-turbo).
+    # To get around this, we initialize the store with the first document, then use
+    # our own super simple rate limiting to handle many large embedding calls.
+    store = vector_store.from_documents(
+        documents=[first_document],
+        embedding=embeddings_model,
+    )
+    # Approximate token usage by length of document content.
+    current_token_usage = len(first_document.page_content)
+    for doc in documents[1:]:
+        if current_token_usage >= tpm_limit:
+            # We do what we can since we don't have access to rate limit headers
+            # https://platform.openai.com/docs/guides/rate-limits/usage-tiers?context=tier-one.
+            time.sleep(rate_limit_interval.total_seconds())
+            current_token_usage = 0
+        store.add_documents([doc])
+        current_token_usage += len(doc.page_content)
+    return store


### PR DESCRIPTION
This PR makes use of [Langchain's MultiVectorRetriever](https://python.langchain.com/docs/modules/data_connection/retrievers/multi_vector) to store multiple vectors per document. In particular, we are storing smaller chunks and then for each chunk, linking to its parent document. This is motivated by [LlamaIndex's post on Building Performant RAG Applications](https://docs.llamaindex.ai/en/stable/optimizing/production_rag.html#decoupling-chunks-used-for-retrieval-vs-chunks-used-for-synthesis). As a follow-up, we should additionally store document summaries with the `MultiVectorRetrieval` to see increased performance.