### PR TITLE
RAG-9: Add Ensemble Retriever Pipeline & Evaluate Performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.idea*
 # C extensions
 *.so
 

--- a/callback_handlers/log_callback_handler.py
+++ b/callback_handlers/log_callback_handler.py
@@ -41,7 +41,7 @@ class LogCallbackHandler(BaseCallbackHandler):
         self, error: Union[Exception, KeyboardInterrupt], **kwargs: Any
     ) -> Any:
         '''Run when LLM errors.'''
-        pass
+        self.logger.exception(error)
 
     def on_chain_start(
         self, serialized: Dict[str, Any], inputs: Dict[str, Any], **kwargs: Any

--- a/evaluate/evaluate.py
+++ b/evaluate/evaluate.py
@@ -14,6 +14,7 @@ from ragas.run_config import RunConfig
 from pandas import DataFrame
 
 from callback_handlers.log_callback_handler import LogCallbackHandler
+from settings import DEFAULT_LLM, DEFAULT_EMBEDDINGS
 
 _DEFAULT_MAX_RAGAS_RETRIES = 20
 _DEFAULT_MAX_RAGAS_WAIT_TIME_SECS = 500
@@ -69,6 +70,8 @@ def evaluate(
 
     result = ragas_evaluate(
         dataset=dataset,
+        llm=DEFAULT_LLM,
+        embeddings=DEFAULT_EMBEDDINGS,
         metrics=[
             context_precision,
             context_recall,

--- a/loaders/directory_loader/csv_loader.py
+++ b/loaders/directory_loader/csv_loader.py
@@ -5,7 +5,7 @@ from typing import Iterator, List
 from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 
-_CONTENT_FIELD_NAMES = ['content', 'text', 'body']
+_CONTENT_FIELD_NAMES = ['content', 'text', 'body','Body','']
 
 
 class CSVLoader(BaseLoader):

--- a/loaders/directory_loader/directory_loader.py
+++ b/loaders/directory_loader/directory_loader.py
@@ -13,9 +13,9 @@ from langchain.text_splitter import HTMLHeaderTextSplitter
 from langchain.text_splitter import MarkdownHeaderTextSplitter
 from langchain.text_splitter import TextSplitter
 from langchain_core.documents.base import Document
-from langchain_openai.embeddings import OpenAIEmbeddings
 
 from loaders.directory_loader.csv_loader import CSVLoader
+from settings import DEFAULT_EMBEDDINGS
 
 DEFAULT_CHUNK_SIZE = 1000
 DEFAULT_CHUNK_OVERLAP = 50
@@ -49,7 +49,7 @@ class DirectoryLoader(BaseLoader):
 
     def _get_text_splitter_from_extension(self, extension: str) -> TextSplitter:
         if extension == '.pdf':
-            return SemanticChunker(OpenAIEmbeddings())
+            return SemanticChunker(DEFAULT_EMBEDDINGS)
         if extension == '.md':
             return MarkdownHeaderTextSplitter(headers_to_split_on=[(
                 '#', 'Header 1'), ('##', 'Header 2'), ('###', 'Header 3')])

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pandas
 seaborn>=0.13.2
 pgvector
 psycopg2-binary
+gpt4all
+rank_bm25

--- a/retrievers/auto_retriever.py
+++ b/retrievers/auto_retriever.py
@@ -35,7 +35,8 @@ class AutoRetriever(BaseRetriever):
             filter_columns: List[str] = None,
             document_description: str = "",
             prompt_template: str = DEFAULT_AUTO_META_PROMPT_TEMPLATE,
-            cardinality_threshold: int = DEFAULT_CARDINALITY_THRESHOLD
+            cardinality_threshold: int = DEFAULT_CARDINALITY_THRESHOLD,
+            vector_store_operator: VectorStoreOperator = None
     ):
         """
         Given a dataframe, use llm to extract metadata from it.
@@ -60,6 +61,7 @@ class AutoRetriever(BaseRetriever):
         self.embeddings_model = embeddings_model
         self.prompt_template = prompt_template
         self.cardinality_threshold = cardinality_threshold
+        self.vector_store_operator = vector_store_operator
 
     def _get_low_cardinality_columns(self, data: pd.DataFrame):
         """
@@ -131,6 +133,8 @@ class AutoRetriever(BaseRetriever):
         Given data either List[Documents] pd.Dataframe,  use it to create a vectorstore.
         :return:
         """
+        if self.vector_store_operator:
+            return self.vector_store_operator.vector_store
         documents = self.df_to_documents() if isinstance(
             self.data, pd.DataFrame) else self.data
         return VectorStoreOperator(vector_store=self.vectorstore,

--- a/retrievers/ensemble_retriever.py
+++ b/retrievers/ensemble_retriever.py
@@ -1,0 +1,44 @@
+import re
+from typing import Dict
+
+from langchain_core.embeddings import Embeddings
+from langchain_core.language_models import BaseChatModel
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableLambda, RunnablePassthrough, RunnableSerializable
+from langchain.retrievers import EnsembleRetriever as LangChainEnsembleRetriever
+from retrievers.base import BaseRetriever
+from settings import (DEFAULT_LLM,
+                      DEFAULT_EMBEDDINGS
+                      )
+
+
+class EnsembleRetriever(BaseRetriever):
+    """
+    A retriever that combines multiple retrievers together with weighted results
+    """
+
+    def __init__(self,
+                 runnable_retrievers,
+                 llm: BaseChatModel = DEFAULT_LLM,
+                 embeddings_model: Embeddings = DEFAULT_EMBEDDINGS
+                 ):
+        self.llm = llm
+        self.embeddings_model = embeddings_model
+        self.retrievers = []
+        self.weights = []
+        self.set_retrievers_weights(runnable_retrievers)
+
+    def set_retrievers_weights(self, runnable_retrievers):
+        self.retrievers = []
+        self.weights = []
+        for config in runnable_retrievers:
+            self.retrievers.append(config['runnable'])
+            self.weights.append(config['weight'])
+
+    def as_runnable(self) -> RunnableSerializable:
+
+        return (
+            LangChainEnsembleRetriever(
+                retrievers=self.retrievers, weights=self.weights)
+        )

--- a/retrievers/multi_vector_retriever.py
+++ b/retrievers/multi_vector_retriever.py
@@ -15,7 +15,7 @@ from langchain_core.vectorstores import VectorStore
 from langchain_openai import ChatOpenAI
 
 from retrievers.base import BaseRetriever
-from settings import DEFAULT_EMBEDDINGS, DEFAUlT_VECTOR_STORE, DEFAULT_LLM_MODEL
+from settings import DEFAULT_EMBEDDINGS, DEFAUlT_VECTOR_STORE, DEFAULT_LLM_MODEL, get_llm
 from utils import VectorStoreOperator
 
 _DEFAULT_ID_KEY = "doc_id"
@@ -39,12 +39,14 @@ class MultiVectorRetriever(BaseRetriever):
     def __init__(
             self,
             documents: List[Document],
+            doc_ids: list[str] = None,
             id_key: str = _DEFAULT_ID_KEY,
             vectorstore: VectorStore = DEFAUlT_VECTOR_STORE,
             parentstore: BaseStore = None,
             text_splitter: TextSplitter = None,
             embeddings_model: Embeddings = DEFAULT_EMBEDDINGS,
-            mode: MultiVectorRetrieverMode = MultiVectorRetrieverMode.BOTH
+            mode: MultiVectorRetrieverMode = MultiVectorRetrieverMode.BOTH,
+            vector_store_operator: VectorStoreOperator = None
     ):
         self.vectorstore = vectorstore
         self.parentstore = parentstore if parentstore is not None else InMemoryByteStore()
@@ -53,6 +55,12 @@ class MultiVectorRetriever(BaseRetriever):
         self.text_splitter = text_splitter
         self.embeddings_model = embeddings_model
         self.mode = mode
+        self.doc_ids = doc_ids
+        if vector_store_operator:
+            self.vector_store_operator = vector_store_operator
+        else:
+            self.vector_store_operator = self._create_vector_store_operator(documents=documents)
+
 
     def _generate_id_and_split_document(self, doc: Document) -> tuple[str, list[Document]]:
         """
@@ -78,30 +86,30 @@ class MultiVectorRetriever(BaseRetriever):
 
     def _create_retriever_and_vs_operator(self, docs: List[Document]) \
             -> tuple[LangChainMultiVectorRetriever, VectorStoreOperator]:
-        vstore_operator = VectorStoreOperator(
-            vector_store=self.vectorstore,
-            documents=docs,
-            embeddings_model=self.embeddings_model
-        )
+
         retriever = LangChainMultiVectorRetriever(
-            vectorstore=vstore_operator.vector_store,
+            vectorstore=self.vector_store_operator.vector_store,
             byte_store=self.parentstore,
             id_key=self.id_key
         )
-        return retriever, vstore_operator
+        return retriever, self.vector_store_operator
 
     def _get_document_summaries(self) -> List[str]:
         chain = (
                 {"doc":lambda x:x.page_content}
                 | ChatPromptTemplate.from_template("Summarize the following document:\n\n{doc}")
-                | ChatOpenAI(max_retries=0, model_name=DEFAULT_LLM_MODEL)
+                | get_llm(max_retries=0)
                 | StrOutputParser()
         )
         return chain.batch(self.documents, {"max_concurrency": _MAX_CONCURRENCY})
 
     def as_runnable(self) -> RunnableSerializable:
-        if self.mode in {MultiVectorRetrieverMode.SPLIT, MultiVectorRetrieverMode.BOTH}:
+        if not self.documents or not self.doc_ids:
             split_docs, doc_ids = self._split_documents()
+        else:
+            split_docs = self.documents
+            doc_ids = self.doc_ids
+        if self.mode in {MultiVectorRetrieverMode.SPLIT, MultiVectorRetrieverMode.BOTH}:
             retriever, vstore_operator = self._create_retriever_and_vs_operator(split_docs)
             summaries = self._get_document_summaries()
             summary_docs = [
@@ -114,7 +122,6 @@ class MultiVectorRetriever(BaseRetriever):
 
         elif self.mode == MultiVectorRetrieverMode.SUMMARIZE:
             summaries = self._get_document_summaries()
-            doc_ids = [str(uuid.uuid4()) for _ in self.documents]
             summary_docs = [
                 Document(page_content=s, metadata={self.id_key: doc_ids[i]})
                 for i, s in enumerate(summaries)

--- a/settings.py
+++ b/settings.py
@@ -1,18 +1,48 @@
 from enum import Enum
 
+from langchain_community.chat_models.ollama import ChatOllama
+from langchain_community.embeddings import GPT4AllEmbeddings
 from langchain_community.vectorstores.chroma import Chroma
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from pydantic_settings import BaseSettings
 
 DEFAULT_CARDINALITY_THRESHOLD = 40
 DEFAULT_POOL_RECYCLE = 3600
+
+#OpenAI LLM Provider Settings
+DEFAULT_LLM_PROVIDER = "openai"
 DEFAULT_LLM_MODEL = "gpt-3.5-turbo"
+
+
+#Ollama LLM Provider Settings
+#DEFAULT_LLM_PROVIDER = "ollama"
+#DEFAULT_LLM_MODEL = "mistral"
+#DEFAULT_LLM_MODEL = "gemma:2b"
+
+#Embedding Settings
+DEFAULT_EMBEDDINGS = OpenAIEmbeddings()
+#DEFAULT_EMBEDDINGS = GPT4AllEmbeddings()
+
+
+DEFAULT_OLLAMA_URL = "http://localhost:11434"
 DEFAULT_CONTENT_COLUMN_NAME = "body"
 DEFAULT_DATASET_DESCRIPTION = "email inbox"
 DEFAULT_TEST_TABLE_NAME = "test_email"
-DEFAULT_LLM = ChatOpenAI(model_name=DEFAULT_LLM_MODEL, temperature=0)
-DEFAULT_EMBEDDINGS = OpenAIEmbeddings()
+
+
+
 DEFAUlT_VECTOR_STORE = Chroma
+
+
+def get_llm(**kwargs):
+    if DEFAULT_LLM_PROVIDER == "openai":
+        return ChatOpenAI(model_name=DEFAULT_LLM_MODEL, **kwargs)
+    if DEFAULT_LLM_PROVIDER == "ollama":
+        return ChatOllama(base_url=DEFAULT_OLLAMA_URL, model=DEFAULT_LLM_MODEL, **kwargs)
+
+
+DEFAULT_LLM = get_llm(temperature=0)  # ChatOpenAI(model_name=DEFAULT_LLM_MODEL, temperature=0)
+
 DEFAULT_AUTO_META_PROMPT_TEMPLATE = """
 Below is a json representation of a table with information about {description}. 
 Return a JSON list with an entry for each column. Each entry should have 
@@ -96,6 +126,9 @@ class RetrieverType(Enum):
     AUTO = 'auto'
     SQL = 'sql'
     MULTI = 'multi'
+    BM25 = 'bm25'
+    ENSEMBLE = 'ensemble'
+    HYBRID = 'hybrid'
 
 
 class InputDataType(Enum):


### PR DESCRIPTION
_Fixes RAG-9_

## Ensemble Retriever:

  The EnsembleRetriever was added, utilizing Langchain's EnsembleRetriever. It allows for the weighted combination of any number of existing retrievers.

Two CLI arguments are added in order to utilize this feature.

```-er --ensemble_retrievers Comma delineated list of retriever types to use with the Ensemble Retriever``` 
e.g. ```-er vector_store,multi```

```-ew --ensemble_weights Comma delineated list of weights, respective in order to the ensemble_retrievers, to use with the Ensemble Retriever``` 
e.g. ```-ew 0.5,0.5```

along with the new RetrieverType
```-r ensemble```


## Performance Evaluation 
_All of these runs were done with gemma:2b / GPT4All Embeddings. You will definitely have higher accuracy scores if you use OpenAI. The additions allowing completely local LLM / Embedding runs are detailed at the bottom of this PR,_

### Vector Store / Multi / Ensemble Combination:
![plot_dummy_vector_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/72941c4c-a131-4499-9515-4332a4c91ebc)
![plot_dummy_multi_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/cdac867c-72d6-416a-b57b-b542ba25a64b)
![plot_dummy_ensemble_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/72e49463-9fff-40b5-8f75-0294ca3b816f)

Ensemble here, notably, has a higher context_recall and answer relevancy. It's Faith-fullness and Context Precision are more mixed together, with less distribution on the extremes.


### BM25 / Vector Store / Hybrid:
![plot_dummy_bm25_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/240f2364-10c3-4181-8ae4-811a688deba8)
![plot_dummy_vector_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/72941c4c-a131-4499-9515-4332a4c91ebc)
![plot_dummy_hybrid_gemma2b](https://github.com/mindsdb/email_rag/assets/123212830/824ef836-4bfc-4254-8174-4c8789afaf6d)

The Hybrid Search did not really do better than Vector Store. However, it did do slightly better on answer relevancy.




## Minor Changes:

- Logging Exceptions passed through "on_llm_error" callbacks.
- Changing llm and embedding calls to universally target settings module.
- Fixes to enable dummy_emails_20 to have enough context to answer evaluations
    -   Expanding _CONTENT_FIELD_NAMES on csv_loader.py
    -   Changed format_docs in rag_pipeliens.py to include metadata in page_content.


## Refactors Required For Ensemble Retriever:
 VectorStoreOperator object is passed through and used with Retrievers that would have otherwise created one. Due to the EnsembleRetriever grouping together multiple Retrievers, we must share the VectorStore or face a Segmentation Fault.

 Refactored arguments for getting a pipeline from a retriever. Arguments are now in an object GetPipelineArgs. _get_pipeline_from_retriever was also refactored and is now just a switch. Individual creations of retrievers are delegated to individual functions. These changes allow the ensemble retriever to use any existing retriever in a seamless way.

Included in GetPipelineArgs is the creation of a VectorStoreOperator that can be shared. This also does the splitting action that Multi_Vector_Retriever does.



## Misc Feature Additions:

BM25 Retriever Type was added to include a sparse retriever.

Hybrid Retriever Type was added as a shortcut to doing ```... -r ensemble -er bm25,vector_store -ew 0.5,0.5```

Calls to OpenAI were all refactored to refer to the settings.py file

GPT4AllEmbeddings can be optionally enabled in settings.py

Ollama and it's LLMs can be optionally enabled in settings.py

GPT4All and Ollama allow for a completely local run of the evaluate_rag process withot requiring OpenAI.

Ollama does require installation and the service needs to be running, with any required models pulled in (e.g. ```ollama pull llama2```). There's also hardware considerations that vary on the model used. I recommend using the gemma:2b LLM with dummy_emails_20 for the quickest local evaluation. Remember to comment and uncomment relevant lines in settings.py

