### PR TITLE
RAG-46 Enable loading of existing pgvector table created in mindsdb to langchain pgvector client

### DIFF
--- a/loaders/vector_store_loader/vector_store_loader.py
+++ b/loaders/vector_store_loader/vector_store_loader.py
@@ -12,10 +12,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.exc import DisconnectionError
 
-COL_ID = "id"
-COL_EMBEDDINGS = "embeddings"
-COL_METADATA = "metadata"
-COL_CONTENT = "content"
+_COL_ID = "id"
+_COL_EMBEDDINGS = "embeddings"
+_COL_METADATA = "metadata"
+_COL_CONTENT = "content"
 
 
 class VectorStoreFactory:
@@ -60,13 +60,13 @@ class VectorStoreFactory:
         """
         df = VectorStoreFactory._fetch_data_from_db(settings)
 
-        df[COL_EMBEDDINGS] = df[COL_EMBEDDINGS].apply(ast.literal_eval)
-        df[COL_METADATA] = df[COL_METADATA].apply(ast.literal_eval)
+        df[_COL_EMBEDDINGS] = df[_COL_EMBEDDINGS].apply(ast.literal_eval)
+        df[_COL_METADATA] = df[_COL_METADATA].apply(ast.literal_eval)
 
-        metadata = df[COL_METADATA].tolist()
-        embeddings = df[COL_EMBEDDINGS].tolist()
-        texts = df[COL_CONTENT].tolist()
-        ids = [str(uuid.uuid1()) for _ in range(len(df))] if COL_ID not in df.columns else df[COL_ID].tolist()
+        metadata = df[_COL_METADATA].tolist()
+        embeddings = df[_COL_EMBEDDINGS].tolist()
+        texts = df[_COL_CONTENT].tolist()
+        ids = [str(uuid.uuid1()) for _ in range(len(df))] if _COL_ID not in df.columns else df[_COL_ID].tolist()
 
         vectorstore.add_embeddings(
             texts=texts,
@@ -91,6 +91,7 @@ class VectorStoreFactory:
 
             return df
         except DisconnectionError as e:
+            # todo replace with logger when integrated in mindsdb
             print("Unable to connect to the database. Please check your connection string and try again.")
             raise e
         finally:

--- a/loaders/vector_store_loader/vector_store_loader.py
+++ b/loaders/vector_store_loader/vector_store_loader.py
@@ -1,8 +1,21 @@
+import ast
+import uuid
+
 from langchain_core.embeddings import Embeddings
 from langchain_community.vectorstores import Chroma, PGVector
 from langchain_core.vectorstores import VectorStore
 from pydantic import BaseModel, parse_obj_as
 from settings import VectorStoreType, VectorStoreConfig
+import pandas as pd
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.exc import DisconnectionError
+
+COL_ID = "id"
+COL_EMBEDDINGS = "embeddings"
+COL_METADATA = "metadata"
+COL_CONTENT = "content"
 
 
 class VectorStoreFactory:
@@ -13,14 +26,14 @@ class VectorStoreFactory:
         else:
             settings = VectorStoreConfig()
         if settings.type == VectorStoreType.CHROMA:
-            return VectorStoreFactory._create_chroma_vectorstore(embeddings_model, settings)
+            return VectorStoreFactory._load_chromadb_store(embeddings_model, settings)
         elif settings.type == VectorStoreType.PGVECTOR:
-            return VectorStoreFactory._create_pgvector_vectorstore(embeddings_model, settings)
+            return VectorStoreFactory._load_pgvector_store(embeddings_model, settings)
         else:
             raise ValueError(f"Invalid vector store type, must be one either {VectorStoreType.__members__.keys()}")
 
     @staticmethod
-    def _create_chroma_vectorstore(embeddings_model: Embeddings, settings):
+    def _load_chromadb_store(embeddings_model: Embeddings, settings) -> Chroma:
         return Chroma(
             persist_directory=settings.persist_directory,
             collection_name=settings.collection_name,
@@ -28,11 +41,49 @@ class VectorStoreFactory:
         )
 
     @staticmethod
-    def _create_pgvector_vectorstore(embeddings_model: Embeddings, settings):
-        return PGVector.from_existing_index(
-            embedding=embeddings_model,
-            **settings.dict()
+    def _load_pgvector_store(embeddings_model: Embeddings, settings) -> PGVector:
+        empty_store = PGVector(
+            connection_string=settings.connection_string,
+            collection_name=settings.collection_name,
+            embedding_function=embeddings_model,
+            pre_delete_collection=True,
         )
+        return VectorStoreFactory._load_data_into_langchain_pgvector(settings, empty_store)
+
+    @staticmethod
+    def _load_data_into_langchain_pgvector(settings, vectorstore: PGVector) -> PGVector:
+        df = VectorStoreFactory._fetch_data_from_db(settings)
+
+        df[COL_EMBEDDINGS] = df[COL_EMBEDDINGS].apply(ast.literal_eval)
+        df[COL_METADATA] = df[COL_METADATA].apply(ast.literal_eval)
+
+        metadata = df[COL_METADATA].tolist()
+        embeddings = df[COL_EMBEDDINGS].tolist()
+        texts = df[COL_CONTENT].tolist()
+        ids = [str(uuid.uuid1()) for _ in range(len(df))] if COL_ID not in df.columns else df[COL_ID].tolist()
+
+        vectorstore.add_embeddings(
+            texts=texts,
+            embeddings=embeddings,
+            metadatas=metadata,
+            ids=ids
+        )
+        return vectorstore
+
+    @staticmethod
+    def _fetch_data_from_db(settings) -> pd.DataFrame:
+        try:
+            engine = create_engine(settings.connection_string)
+            db = scoped_session(sessionmaker(bind=engine))
+
+            df = pd.read_sql(f"SELECT * FROM {settings.collection_name}", engine)
+
+            return df
+        except DisconnectionError as e:
+            print("Unable to connect to the database. Please check your connection string and try again.")
+            raise e
+        finally:
+            db.close()
 
 
 class VectorStoreLoader(BaseModel):


### PR DESCRIPTION
1. Connects to database containing pgvector table and retrieves all the data.
2. Loads data into langchain pgvector client, creating a new collection if it doesn't alrerady exist or loading into a existing langchain pgvector collection

Fixes RAG-46