### PR TITLE
RAG-9 Reranking Addition

### DIFF
--- a/evaluate/evaluate.py
+++ b/evaluate/evaluate.py
@@ -51,6 +51,7 @@ def evaluate(
 
     answers = []
     contexts = []
+    reranked_docs = []
     num_questions = len(questions)
     for i, question in enumerate(questions):
         logging.info('Answering question {} of {}'.format(
@@ -59,6 +60,8 @@ def evaluate(
         answers.append(result['answer'])
         contexts.append(
             [docs.page_content for docs in result['context']])
+        if 'reranked_docs' in result:
+            reranked_docs.append(result['reranked_docs'])
 
     data = {
         'question': questions,
@@ -66,6 +69,8 @@ def evaluate(
         'contexts': contexts,
         'ground_truths': ground_truths
     }
+    if len(reranked_docs) != 0:
+        data['reranked_docs'] = reranked_docs
     dataset = Dataset.from_dict(data)
 
     result = ragas_evaluate(

--- a/settings.py
+++ b/settings.py
@@ -30,7 +30,7 @@ DEFAULT_DATASET_DESCRIPTION = "email inbox"
 DEFAULT_TEST_TABLE_NAME = "test_email"
 
 
-
+DEFAULT_RERANK = False
 DEFAUlT_VECTOR_STORE = Chroma
 
 
@@ -115,6 +115,29 @@ DEFAULT_SQL_RETRIEVAL_PROMPT_TEMPLATE = {
                 "sql_result": DEFAULT_SQL_RESULT_PROMPT_TEMPLATE
             }
 
+DEFAULT_RERANKING_PROMPT_TEMPLATE = """
+A list of documents is shown below. Each document has a number next to it along with a summary of the document. A question is also provided.
+  Respond with the numbers of the documents you should consult to answer the question, in order of relevance, as well
+  as the relevance score. The relevance score is a number from 1–10 based on how relevant you think the document is to the question.
+  Do not include any documents that are not relevant to the question.
+  Example format:
+  Document 1:
+  <summary of document 1>
+  Document 2:
+  <summary of document 2>
+  …
+  Document 10:
+  <summary of document 10>
+  Question: <question>
+  Answer:
+  Doc: 9, Relevance: 7
+  Doc: 3, Relevance: 4
+  Doc: 7, Relevance: 3
+  Let's try this now:
+  {context_str}
+  Question: {query_str}
+  Answer:
+"""
 
 class VectorStoreType(Enum):
     CHROMA = 'chroma'


### PR DESCRIPTION
This PR adds LLM based reranking to the RAG pipeline.
It is enabled with the option `-rd true`, which will add a step of reranking any documents it finds to only include one's found relevant by the LLM. This will also increase the initial k value / document results from 5 -> 40 coming from the retrievers (aside from the summary retriever). 

Reranking only seems to work on higher-end models like GPT-3.5-turbo. Using it with a local mistral has varied results, and gemma:2b just does not work at all. More refining of the reranking prompt, as well as the extraction of document IDs (potentially moving to JSON output) would help in this regard.

After some tests, results seem a bit better than using previous methods. 